### PR TITLE
Adding support for replacing default dao params with widget specific

### DIFF
--- a/module/Dashboard/src/Dashboard/Model/Dao/AbstractDao.php
+++ b/module/Dashboard/src/Dashboard/Model/Dao/AbstractDao.php
@@ -336,7 +336,9 @@ abstract class AbstractDao implements ServiceLocatorAwareInterface
         $this->validateUrlParamValues($url, $params);
 
         foreach ($params as $key => $value) {
-            $url = str_replace(':' . $key . ':', $value, $url);
+            if (!is_array($value)) {
+                $url = str_replace(':' . $key . ':', $value, $url);
+            }
         }
 
         return $url;

--- a/module/Dashboard/src/Dashboard/Model/DashboardManager.php
+++ b/module/Dashboard/src/Dashboard/Model/DashboardManager.php
@@ -122,6 +122,11 @@ class DashboardManager
                 $daoParams = array();
                 if (isset($widgetData['params']['dao']) && isset($this->rtmConfig[$widgetData['params']['dao']])) {
                     $daoParams = $this->rtmConfig[$widgetData['params']['dao']];
+
+                }
+
+                if (isset($widgetData['params']['daoOptions'])) {
+                    $daoParams = array_replace_recursive($daoParams, $widgetData['params']['daoOptions']);
                 }
 
                 $widget = $widgetFactory->build($widgetData, $daoParams, $this->getResourceName());


### PR DESCRIPTION
Adding support for replacing default dao params with widget specific ones that OVERWRITE the general dao. They can be specified in widget configuration in $widget['params']['daoOptions'] index.
