### PR TITLE
Fix config gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ composer.lock
 composer.phar
 vendor/
 public/vendor/
+config/environment.config.php
 config/autoload/local.php
 config/autoload/*.local.php
 public/vendor/*


### PR DESCRIPTION
environment.config.php was tracked by git repository before it was added to gitignore, so every time this file was created git wanted to commit it even it was listed in .gitignore
