### PR TITLE
Added fallback for fetching threshold to config values

### DIFF
--- a/module/Dashboard/src/Dashboard/Model/Dao/NewRelicDao.php
+++ b/module/Dashboard/src/Dashboard/Model/Dao/NewRelicDao.php
@@ -524,6 +524,9 @@ class NewRelicDao extends AbstractDao
                     break;
                 }
             }
+            if (empty($result)) {
+                throw new EndpointUrlNotAssembled('Could not find requested metric thresholds');
+            }
         } catch (EndpointUrlNotAssembled $e) {
             $result = array(
                 'caution-value' => isset($params['caution-value']) ? $params['caution-value'] : 0,


### PR DESCRIPTION
Changes applies to NewRelic Dao. 
If thresholds for current metric cannot be found in NewRelic the threshold values would be rewritten to once provided in the config file.