### PR TITLE
Changes around google-prettify

### DIFF
--- a/module/Application/view/application/index/index.phtml
+++ b/module/Application/view/application/index/index.phtml
@@ -17,3 +17,7 @@
         </div>
     </div>
 </div>
+<?php echo $this->inlineScript()
+    ->appendFile('https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js?skin=desert')
+;
+?>

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -65,7 +65,6 @@
     ->appendFile($this->basePath() . '/js/jquery.knob.js')
     ->appendFile($this->basePath() . '/js/jquery.blink.js')
     ->appendFile($this->basePath() . '/js/showdown.js')
-    ->appendFile('//google-code-prettify.googlecode.com/svn/loader/run_prettify.js?skin=desert')
 ;
 ?>
 </body>

--- a/public/js/extensions/prettify.js
+++ b/public/js/extensions/prettify.js
@@ -1,6 +1,0 @@
-//
-//  Google Prettify
-//  A showdown extension to add Google Prettify (http://code.google.com/p/google-code-prettify/)
-//  hints to showdown's HTML output.
-//
-(function(){var a=function(a){return[{type:"output",filter:function(a){return a.replace(/(<pre>)?<code>/gi,function(a,b){return b?'<pre class="prettyprint linenums" tabIndex="0"><code data-inner="1">':'<code class="prettyprint">'})}}]};typeof window!="undefined"&&window.Showdown&&window.Showdown.extensions&&(window.Showdown.extensions.prettify=a),typeof module!="undefined"&&(module.exports=a)})();


### PR DESCRIPTION
1. Previous cdn doesn't work anymore. I've used [the link from official docs](https://github.com/google/code-prettify#setup)
2. Prettify was loaded for every dashboard and wasn't needed. Changed to append it only for index route.
3. Removed not used `extension/prettify.js`
